### PR TITLE
impemented --runtime-args flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ same-file = "1.0"
 semver = "0.9"
 serde = { version = "1", features = ['derive'] }
 serde_json = "1"
+structopt = "0.3.5"
 tar = "0.4"
 tempfile = "3"
 termcolor = "1.0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   'crates/cargo-wasi-shim',
   'examples/markdown',
   'examples/hello-world',
+  'examples/read-file',
 ]
 exclude = ['tmp', 'target']
 

--- a/doc/cli-usage.md
+++ b/doc/cli-usage.md
@@ -38,8 +38,9 @@ $ cargo wasi check --tests
 ## `cargo wasi run`
 
 Forwards everything to `cargo run`, and runs all binaries in `wasmtime`.
-Arguments passed will be forwarded to `wasmtime`. Note that it's not
-necessary to run `cargo wasi build` before this subcommand. Example usage looks
+Arguments passed will be forwarded to binaries. Additional runtime arguments
+may be passed using `--runtime-args`. Note that it's not necessary to
+run `cargo wasi build` before this subcommand. Example usage looks
 like:
 
 ```
@@ -47,6 +48,7 @@ $ cargo wasi run
 $ cargo wasi run --release
 $ cargo wasi run arg1 arg2
 $ cargo wasi run -- --flag-for-wasm-binary
+$ cargo wasi run -- --runtime-args "--dir=."
 $ cargo wasi run --bin foo
 ```
 

--- a/examples/read-file/Cargo.toml
+++ b/examples/read-file/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "read-file"
+version = "0.1.0"
+authors = ["cargo-wasi contributors"]
+edition = "2018"

--- a/examples/read-file/README.md
+++ b/examples/read-file/README.md
@@ -1,0 +1,7 @@
+## Fs example
+
+An example of reading a file in wasi
+
+```bash
+cargo wasi run -- --runtime-args --dir=.
+```

--- a/examples/read-file/data.txt
+++ b/examples/read-file/data.txt
@@ -1,0 +1,1 @@
+some text

--- a/examples/read-file/src/main.rs
+++ b/examples/read-file/src/main.rs
@@ -1,0 +1,8 @@
+use std::fs::read;
+use std::io;
+
+fn main() -> io::Result<()> {
+    let data = String::from_utf8(read("data.txt")?).unwrap();
+    println!("File contents: {}", data);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use crate::cache::Cache;
 use crate::config::Config;
 use crate::utils::CommandExt;
 use anyhow::{bail, Context, Result};
+use structopt::StructOpt;
 use std::env;
 use std::fs;
 use std::io::{self, Read};
@@ -44,10 +45,32 @@ enum Subcommand {
     Fix,
 }
 
+#[derive(StructOpt, Debug)]
+struct Build {
+    #[structopt(long)]
+    runtime_args: String,
+    binary_args: Vec<String>,
+}
+
+#[derive(StructOpt, Debug)]
+enum Options {
+    Build(Build),
+    Run,
+    Test,
+    Bench,
+    Check,
+    Fix,
+    #[structopt(name = "self")]
+    Main,
+}
+
 fn rmain(config: &mut Config) -> Result<()> {
     config.load_cache()?;
 
     // skip the current executable and the `wasi` inserted by Cargo
+    println!("Raw args: {:?}", env::args());
+    let options = Options::from_args();
+    println!("Args from structopt: {:?}", options);
     let mut args = env::args_os().skip(2);
     let subcommand = args.next().and_then(|s| s.into_string().ok());
     let subcommand = match subcommand.as_ref().map(|s| s.as_str()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,9 +177,11 @@ fn rmain(config: &mut Config) -> Result<()> {
 
     for run in build.runs.iter() {
         config.status("Running", &format!("`{}`", run.join(" ")));
+        let (runtime_args, binary_args) = utils::split_args(run);
         Command::new("wasmtime")
+            .args(runtime_args.iter())
             .arg("--")
-            .args(run.iter())
+            .args(binary_args.iter())
             .run()
             .map_err(|e| utils::hide_normal_process_exit(e, config))?;
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -163,7 +163,7 @@ pub fn split_args(args: &[String]) -> (Vec<String>, Vec<String>) {
         let argument = &args[i];
         if argument == "--runtime-args" {
             if i + 1 < args.len() {
-                runtime_args.extend_from_slice(&args[i+1..]);
+                runtime_args.extend_from_slice(&args[i + 1..]);
             }
             break;
         } else {
@@ -177,10 +177,7 @@ pub fn split_args(args: &[String]) -> (Vec<String>, Vec<String>) {
 #[test]
 fn split_args_empty() {
     let (runtime_args, binary_args) = split_args(&[]);
-    assert_eq!(
-        (runtime_args, binary_args),
-        (vec![], vec![]),
-    );
+    assert_eq!((runtime_args, binary_args), (vec![], vec![]),);
 }
 
 #[test]
@@ -193,8 +190,9 @@ fn split_args_only_binary() {
 }
 
 #[test]
-fn split_args_only_runtime()  {
-    let (runtime_args, binary_args) = split_args(&vec!["--runtime-args".to_owned(), "--dir=.".to_owned()]);
+fn split_args_only_runtime() {
+    let (runtime_args, binary_args) =
+        split_args(&vec!["--runtime-args".to_owned(), "--dir=.".to_owned()]);
     assert_eq!(
         (runtime_args, binary_args),
         (vec!["--dir=.".to_owned()], vec![]),
@@ -203,7 +201,11 @@ fn split_args_only_runtime()  {
 
 #[test]
 fn split_args_runtime_before_binary() {
-    let (runtime_args, binary_args) = split_args(&vec!["--runtime-args".to_owned(), "--dir=.".to_owned(), "a".to_owned()]);
+    let (runtime_args, binary_args) = split_args(&vec![
+        "--runtime-args".to_owned(),
+        "--dir=.".to_owned(),
+        "a".to_owned(),
+    ]);
     assert_eq!(
         (runtime_args, binary_args),
         (vec!["--dir=.".to_owned(), "a".to_owned()], vec![]),
@@ -212,7 +214,11 @@ fn split_args_runtime_before_binary() {
 
 #[test]
 fn split_args_runtime_after_binary() {
-    let (runtime_args, binary_args) = split_args(&vec!["a".to_owned(), "--runtime-args".to_owned(), "--dir=.".to_owned()]);
+    let (runtime_args, binary_args) = split_args(&vec![
+        "a".to_owned(),
+        "--runtime-args".to_owned(),
+        "--dir=.".to_owned(),
+    ]);
     assert_eq!(
         (runtime_args, binary_args),
         (vec!["--dir=.".to_owned()], vec!["a".to_owned()]),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -154,3 +154,67 @@ pub fn get(url: &str) -> Result<reqwest::Response> {
     }
     Ok(response)
 }
+
+pub fn split_args(args: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut runtime_args = vec![];
+    let mut binary_args = vec![];
+
+    for i in 0..args.len() {
+        let argument = &args[i];
+        if argument == "--runtime-args" {
+            if i + 1 < args.len() {
+                runtime_args.extend_from_slice(&args[i+1..]);
+            }
+            break;
+        } else {
+            binary_args.push(argument.clone());
+        }
+    }
+
+    (runtime_args, binary_args)
+}
+
+#[test]
+fn split_args_empty() {
+    let (runtime_args, binary_args) = split_args(&[]);
+    assert_eq!(
+        (runtime_args, binary_args),
+        (vec![], vec![]),
+    );
+}
+
+#[test]
+fn split_args_only_binary() {
+    let (runtime_args, binary_args) = split_args(&vec!["a".to_owned(), "b".to_owned()]);
+    assert_eq!(
+        (runtime_args, binary_args),
+        (vec![], vec!["a".to_owned(), "b".to_owned()]),
+    );
+}
+
+#[test]
+fn split_args_only_runtime()  {
+    let (runtime_args, binary_args) = split_args(&vec!["--runtime-args".to_owned(), "--dir=.".to_owned()]);
+    assert_eq!(
+        (runtime_args, binary_args),
+        (vec!["--dir=.".to_owned()], vec![]),
+    );
+}
+
+#[test]
+fn split_args_runtime_before_binary() {
+    let (runtime_args, binary_args) = split_args(&vec!["--runtime-args".to_owned(), "--dir=.".to_owned(), "a".to_owned()]);
+    assert_eq!(
+        (runtime_args, binary_args),
+        (vec!["--dir=.".to_owned(), "a".to_owned()], vec![]),
+    );
+}
+
+#[test]
+fn split_args_runtime_after_binary() {
+    let (runtime_args, binary_args) = split_args(&vec!["a".to_owned(), "--runtime-args".to_owned(), "--dir=.".to_owned()]);
+    assert_eq!(
+        (runtime_args, binary_args),
+        (vec!["--dir=.".to_owned()], vec!["a".to_owned()]),
+    );
+}


### PR DESCRIPTION
This pr adds the ability to pass arguments to runtime using `--runtime-args` flag.
At the moment I made a naive implementation of `split_args` function to separate arguments intended for binary from ones intended for runtime. Is it planned to use a library like `clap` or `structopt`? It may simplify the work with arguments a bit

Closes #17 