### PR TITLE
Note that wasm-bindgen required release mode in the guide

### DIFF
--- a/doc/wasm-bindgen.md
+++ b/doc/wasm-bindgen.md
@@ -4,6 +4,10 @@
 > experimental, it's recommended that you expect breakage and/or surprises if
 > you're using this.
 
+> **Note**: When building your crate with WebAssembly Interface Types enabled
+> via `wasm-bindgen`, due to a bug in `wasm-bindgen`, it is currently necessary
+> to build in release mode, i.e., `cargo wasi build --release`.
+
 The [`wasm-bindgen` project](https://github.com/rustwasm/wasm-bindgen) is
 primarily targeted at JavaScript and the web, but is also becomimg the primary
 experiment grounds of WebAssembly Interface Types for Rust. If you're not using


### PR DESCRIPTION
This commit adds a note to the guide book, under the `wasm-bindgen`
section, that release mode for compilation is required when
building with WASI Interface Types enabled via `wasm-bindgen`.

This commit is a temp solution for the `wasm-bindgen` bug tracked
via #24.