### PR TITLE
Check CARGO_TARGET_WASM32_WASI_RUNNER for runtime override

### DIFF
--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -10,7 +10,7 @@ https://github.com/bytecodealliance/cargo-wasi.
    installed](https://www.rust-lang.org/tools/install)
 
 2. Running tests requires [`wasmtime` is installed and in
-   `$PATH`](https://wasmtime.dev)
+   `$PATH`](https://wasmtime.dev) or an existing runtime provided via `CARGO_TARGET_WASM32_WASI_RUNNER`.
 
 ## Getting the code
 

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -514,7 +514,7 @@ $",
         .build()
         .cargo_wasi("run")
         .assert()
-        .stdout(is_match("target/wasm32-wasi/debug/foo.wasm")?)
+        .stdout(is_match("target.wasm32-wasi.debug.foo.wasm")?)
         .stderr(is_match(
             "^\
 .*Compiling foo v1.0.0 .*

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -419,6 +419,116 @@ $",
 }
 
 #[test]
+fn run_override_runtime() -> Result<()> {
+    support::project()
+        .file("src/main.rs", "fn main() {}")
+        .override_runtime("wasmtime")
+        .build()
+        .cargo_wasi("run")
+        .assert()
+        .stdout("")
+        .stderr(is_match(
+            "^\
+.*Compiling foo v1.0.0 .*
+.*Finished dev .*
+.*Running `.*`
+.*Running `.*`
+$",
+        )?)
+        .success();
+
+    // override fails properly
+    support::project()
+        .file("src/main.rs", "fn main() {}")
+        .override_runtime(
+            "command-and-path-that-is-unlikely-to-exist-eac9cb6c-fa25-4487-b07f-38116cc6dade",
+        )
+        .build()
+        .cargo_wasi("run")
+        .assert()
+        .stdout("")
+        // error should include this environment variable
+        .stderr(is_match("CARGO_TARGET_WASM32_WASI_RUNNER")?)
+        .failure();
+
+    // override with a working runtime works
+    support::project()
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() { println!("hello") }
+            "#,
+        )
+        .override_runtime("wasmtime")
+        .build()
+        .cargo_wasi("run")
+        .assert()
+        .stdout("hello\n")
+        .stderr(is_match(
+            "^\
+.*Compiling foo v1.0.0 .*
+.*Finished dev .*
+.*Running `.*`
+.*Running `.*`
+$",
+        )?)
+        .success();
+
+    let wasmtime_path = which::which("wasmtime")
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    // override with a file path works
+    support::project()
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() { println!("hello") }
+            "#,
+        )
+        .override_runtime(&wasmtime_path)
+        .build()
+        .cargo_wasi("run")
+        .assert()
+        .stdout("hello\n")
+        .stderr(is_match(
+            "^\
+.*Compiling foo v1.0.0 .*
+.*Finished dev .*
+.*Running `.*`
+.*Running `.*`
+$",
+        )?)
+        .success();
+
+    // override is not accidentally using wasmtime
+    // use the `echo` program to test this
+    support::project()
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() { println!("hello") }
+            "#,
+        )
+        .override_runtime("echo")
+        .build()
+        .cargo_wasi("run")
+        .assert()
+        .stdout(is_match("target/wasm32-wasi/debug/foo.wasm")?)
+        .stderr(is_match(
+            "^\
+.*Compiling foo v1.0.0 .*
+.*Finished dev .*
+.*Running `.*`
+.*Running `.*`
+$",
+        )?)
+        .success();
+
+    Ok(())
+}
+
+#[test]
 fn run_forward_args() -> Result<()> {
     support::project()
         .file(


### PR DESCRIPTION
Hello!

This PR uses the `CARGO_TARGET_WASM32_WASI_RUNNER` environment variable to conditionally override `wasmtime` as the WASI runner.  Let me know if you'd like to see any changes!
 
Resolves #13