### PR TITLE
fix: wasm_opt

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,17 @@ jobs:
       run: rustup update beta && rustup update stable && rustup default beta
     - run: cargo install --debug --path .
 
+    # target `wasm32-unknown-unknown` will not be installed automatically
+    - run: rustup target add wasm32-unknown-unknown
+
     # Verify that we can switch between channels (stable/beta) and we'll
     # automatically get the wasi target on both.
     - run: (cd examples/hello-world && cargo +stable wasi build --release -v)
     - run: (cd examples/hello-world && cargo +beta wasi build --release -v)
 
-    # Run this twice just to make sure it's fresh the second time
-    - run: (cd examples/markdown && cargo wasi build --release -v)
-    - run: (cd examples/markdown && cargo wasi build --release -v)
+    # Run this twice just to make sure it's fresh the second time, and verify that we can override arguments
+    - run: (cd examples/markdown && cargo wasi build --release -v --target wasm32-unknown-unknown)
+    - run: (cd examples/markdown && cargo wasi build --release -v --target wasm32-unknown-unknown)
 
   build:
     name: Build

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ impl Config {
     /// `wasm-bindgen` used, or `WASM_OPT=path/to/wasm-opt` for `wasm-opt`.  or
     /// the `cache` as the fallback.
     fn get_tool(&self, tool: &str, version: Option<&str>) -> (PathBuf, PathBuf) {
-        let mut cache_path = self.cache().root().join(tool);
+        let mut cache_path = self.cache().root().join("bin").join(tool);
         if let Some(v) = version {
             cache_path.push(v);
             cache_path.push(tool)
@@ -104,6 +104,10 @@ impl Config {
         } else {
             (cache_path.clone(), cache_path)
         }
+    }
+
+    pub fn get_ld_library_path(&self) -> PathBuf {
+        self.cache().root().join("lib")
     }
 
     /// Get the path to our `wasm-bindgen` tool for the given version, and the


### PR DESCRIPTION
1. As @PiotrSikora says, in order to run`wasm_opt`, a dynamic library needs to be installed (for Linux and mac os). https://github.com/bytecodealliance/cargo-wasi/pull/91#issuecomment-787433832
And the cache folder's structure will be as follow. 

![image](https://user-images.githubusercontent.com/42082890/154807532-5f2c875b-9f0c-4f68-9e94-f870fc13fc93.png)

2. update `wasm_opt` version from `version_97` to `version_105`