### PR TITLE
Update binaryen version to 109

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,7 @@ fn run_or_download(
 }
 
 fn install_wasm_opt(path: &Path, config: &Config) -> Result<()> {
-    let tag = "version_97";
+    let tag = "version_109";
     let binaryen_url = |target: &str| {
         let mut url = "https://github.com/WebAssembly/binaryen/releases/download/".to_string();
         url.push_str(tag);


### PR DESCRIPTION
This version includes binaries for MacOS running on Apple Silicon. This
change will make it easier to perform future changes to better support
Apple Silicon.