### PR TITLE
Get wasm-opt working on MacOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,11 +127,16 @@ impl Config {
             let mut bin = ["bin", "wasm-opt"].iter().collect::<PathBuf>();
             bin.set_extension(std::env::consts::EXE_EXTENSION);
 
-            let mut archive = ["lib", "libbinaryen"].iter().collect::<PathBuf>();
-            archive.set_extension(std::env::consts::DLL_EXTENSION);
-
             let bin_path = path.join(&bin);
-            let sub_paths = vec![bin, archive];
+            let mut sub_paths = vec![bin];
+
+            // wasm-opt on MacOS requires a dylib to execute
+            if cfg!(target_os = "macos") {
+                let mut dylib = ["lib", "libbinaryen"].iter().collect::<PathBuf>();
+                dylib.set_extension(std::env::consts::DLL_EXTENSION);
+                sub_paths.push(dylib);
+            }
+
             ToolPath::Cached {
                 bin_path,
                 base: path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::Cache;
+use crate::{Cache, ToolPath};
 use anyhow::Result;
 use std::path::PathBuf;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
@@ -99,8 +99,6 @@ impl Config {
                 cache_path.push(v);
                 cache_path.push(tool)
             }
-            cache_path.set_extension(std::env::consts::EXE_EXTENSION);
-
             (cache_path, false)
         }
     }
@@ -111,7 +109,11 @@ impl Config {
     ///
     /// Overridable via setting the `WASM_BINDGEN=path/to/wasm-bindgen` env var.
     pub fn get_wasm_bindgen(&self, version: &str) -> (PathBuf, bool) {
-        self.get_tool("wasm-bindgen", Some(version))
+        let (mut path, is_overridden) = self.get_tool("wasm-bindgen", Some(version));
+        if !is_overridden {
+            path.set_extension(std::env::consts::EXE_EXTENSION);
+        }
+        (path, is_overridden)
     }
 
     /// Get the path to our `wasm-opt`, which may be the cache path where it
@@ -119,7 +121,24 @@ impl Config {
     /// overridden.
     ///
     /// Overridable via setting the `WASM_OPT=path/to/wasm-opt` env var.
-    pub fn get_wasm_opt(&self) -> (PathBuf, bool) {
-        self.get_tool("wasm-opt", None)
+    pub fn get_wasm_opt(&self) -> ToolPath {
+        let (path, is_overridden) = self.get_tool("wasm-opt", None);
+        if !is_overridden {
+            let mut bin = ["bin", "wasm-opt"].iter().collect::<PathBuf>();
+            bin.set_extension(std::env::consts::EXE_EXTENSION);
+
+            let mut archive = ["lib", "libbinaryen"].iter().collect::<PathBuf>();
+            archive.set_extension(std::env::consts::DLL_EXTENSION);
+
+            let bin_path = path.join(&bin);
+            let sub_paths = vec![bin, archive];
+            ToolPath::Cached {
+                bin_path,
+                base: path,
+                sub_paths,
+            }
+        } else {
+            ToolPath::Overridden(path)
+        }
     }
 }

--- a/src/tool_path.rs
+++ b/src/tool_path.rs
@@ -1,0 +1,36 @@
+use std::path::{Path, PathBuf};
+
+pub enum ToolPath {
+    Overridden(PathBuf),
+    Cached {
+        bin_path: PathBuf,
+        base: PathBuf,
+        sub_paths: Vec<PathBuf>,
+    },
+}
+
+impl ToolPath {
+    pub fn is_overridden(&self) -> bool {
+        if let ToolPath::Overridden(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn bin_path(&self) -> &Path {
+        match self {
+            ToolPath::Overridden(p) => p,
+            ToolPath::Cached { bin_path, .. } => bin_path,
+        }
+    }
+
+    pub fn cache_paths(&self) -> Option<(&std::path::Path, &Vec<PathBuf>)> {
+        match self {
+            ToolPath::Cached {
+                base, sub_paths, ..
+            } => Some((base, sub_paths)),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Fixes #112 and adds supports downloading `wasm-opt` when running on Apple Silicon.

This also introduces a `ToolPath` struct for representing the various paths involved with `wasm-opt`. I tried doing this without introducing a new type but the code is harder to follow IMO. There's the path to the binary, the base path, the subpaths, and whether the binary path is an overridden path that need to all be represented and used correctly.

I also debated whether to adjust the `get_wasm_bindgen` function to return that `ToolPath` type. I opted against it because it doesn't add any value beyond consistency with `get_wasm_opt`'s signature. I would be okay with changing `get_wasm_bindgen` in a similar manner if that's preferred.

I also considered trying to keep the code adjustments more local to `install_wasm_opt` but couldn't figure out a clean way to deal with the path being returned sometimes being a path to the binary and sometimes being a path to the cache directory without introducing something similar to `ToolPath`.