### PR TITLE
fix: cargo wasi test preopen cwd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ fn rmain(config: &mut Config) -> Result<()> {
         .map(|runner_override| (runner_override, false))
         .unwrap_or_else(|_| ("wasmtime".to_string(), true));
 
-    // Treat the wasi_runner variable as an exectable, followed by a whitespace-
+    // Treat the wasi_runner variable as an executable, followed by a whitespace-
     // separated list of arguments to the executable. This allows the user to
     // provide arguments which are passed to wasmtime without having to add more
     // command-line argument parsing to this crate.
@@ -124,10 +124,15 @@ fn rmain(config: &mut Config) -> Result<()> {
         let runner = words
             .next()
             .ok_or_else(|| anyhow!("$CARGO_TARGET_WASM32_WASI_RUNNER must not be empty"))?;
-        let extra_args = words.collect::<Vec<_>>();
+        let mut extra_args = words.collect::<Vec<_>>();
+
+        // Tests should be run with the current working directory preopened.
+        if let Subcommand::Test = subcommand {
+            extra_args.push("--dir=.");
+        }
+
         (runner, extra_args)
     };
-
     match subcommand {
         Subcommand::Run | Subcommand::Bench | Subcommand::Test => {
             if !using_default {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -585,6 +585,54 @@ $",
 }
 
 #[test]
+fn test_read_file() -> Result<()> {
+    support::project()
+        .file("tests/data.txt", "42")
+        .file(
+            "src/lib.rs",
+            r#"
+use std::fs;
+use std::io;
+use std::path::Path;
+#[allow(dead_code)]
+fn readfile() -> Result<String, io::Error> {
+    let contents = fs::read_to_string(Path::new("tests/data.txt"))
+    .expect("Should have been able to read the file");
+    Ok(contents)
+}
+
+#[test]
+fn read() {
+    let contents = readfile().unwrap();
+    assert_eq!(contents, "42");
+}
+            "#,
+        )
+        .build()
+        .cargo_wasi("test")
+        .assert()
+        .stdout(
+            "
+running 1 test
+test read ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+",
+        )
+        .stderr(is_match(
+            "^\
+.*Compiling foo v1.0.0 .*
+.*Finished .*
+.*Running .*
+.*Running `.*`
+$",
+        )?)
+        .success();
+    Ok(())
+}
+
+#[test]
 fn run_nothing() -> Result<()> {
     support::project()
         .file("src/lib.rs", "")


### PR DESCRIPTION
This PR defaults `cargo wasi test` to always be run
with the current working directory preopened.
The goal is to allow existing tests to run without modification.

Fixes #128