### PR TITLE
Use rustls instead of openssl for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,7 @@ path = "src/main.rs"
 name = "cargo_wasi"
 
 [workspace]
-members = [
-  'crates/assemble',
-  'crates/cargo-wasi-shim',
-  'examples/hello-world',
-]
+members = ['crates/assemble', 'crates/cargo-wasi-shim', 'examples/hello-world']
 exclude = ['tmp', 'target']
 
 [dependencies]
@@ -33,7 +29,11 @@ atty = "0.2"
 dirs = "3.0.1"
 flate2 = "1"
 fs2 = "0.4"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = [
+  "blocking",
+  "json",
+  "rustls-tls",
+], default-features = false }
 rustc-demangle = "0.1.16"
 same-file = "1.0"
 semver = "0.11"


### PR DESCRIPTION
This enables rustls support in reqwest to avoid the openssl-sys dependency.

Otherwise cargo install wasi may fail on systems that are not setup for C development and are missing either `pkg-config` or the respective `libssl` packag