### PR TITLE
Enable bulk memory in wasm-opt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,6 +621,8 @@ fn run_wasm_opt(
     cmd.arg(&input);
     cmd.arg(format!("-O{}", profile.opt_level));
     cmd.arg("-o").arg(wasm);
+    // Rust 1.67+ emits bulk memory instructions
+    cmd.arg("--enable-bulk-memory");
 
     if build.enable_name_section(profile) {
         cmd.arg("--debuginfo");


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/cargo-wasi/issues/133