### PR TITLE
Download wasm-opt 113 to support sign-ext instructions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -699,7 +699,7 @@ fn run_or_download(
 }
 
 fn install_wasm_opt(path: &ToolPath, config: &Config) -> Result<()> {
-    let tag = "version_109";
+    let tag = "version_113";
     let binaryen_url = |target: &str| {
         let mut url = "https://github.com/WebAssembly/binaryen/releases/download/".to_string();
         url.push_str(tag);

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -331,7 +331,7 @@ fn wasm_bindgen() -> Result<()> {
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process \"my-wasm-bindgen.* \"--keep-debug\".*
+    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.* \"--keep-debug\".*
 
 Caused by:
     .*
@@ -349,7 +349,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process \"my-wasm-bindgen.*
+    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.*
 
 Caused by:
     .*
@@ -369,7 +369,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process \"my-wasm-bindgen.*
+    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.*
 
 Caused by:
     .*

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -331,7 +331,7 @@ fn wasm_bindgen() -> Result<()> {
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.* \"--keep-debug\".*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.* \"--keep-debug\".*
 
 Caused by:
     .*
@@ -349,7 +349,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.*
 
 Caused by:
     .*
@@ -369,7 +369,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process WASM_INTERFACE_TYPES=\"1\" \"my-wasm-bindgen.*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.*
 
 Caused by:
     .*

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -331,7 +331,7 @@ fn wasm_bindgen() -> Result<()> {
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.* \"--keep-debug\".*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\" )?\"my-wasm-bindgen.* \"--keep-debug\".*
 
 Caused by:
     .*
@@ -349,7 +349,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\" )?\"my-wasm-bindgen.*
 
 Caused by:
     .*
@@ -369,7 +369,7 @@ $",
 error: failed to process wasm at `.*foo.rustc.wasm`
 
 Caused by:
-    failed to create process (WASM_INTERFACE_TYPES=\"1\")? \"my-wasm-bindgen.*
+    failed to create process (WASM_INTERFACE_TYPES=\"1\" )?\"my-wasm-bindgen.*
 
 Caused by:
     .*


### PR DESCRIPTION
Fixes #137.

Rust 1.70 started emitting `sign-ext` instructions in its Wasm output which `wasm-opt` 109 cannot validate. `wasm-opt` 111 introduced support for these instructions.

Also including a change I seemed to need to make to get a `wasm_bindgen` test passing in CI.